### PR TITLE
The uwsgi spooler can be called like this:

### DIFF
--- a/uwsgidecoratorsfallback.py
+++ b/uwsgidecoratorsfallback.py
@@ -1,27 +1,48 @@
 class BaseDecorator(object):
     @property
     def spool(self):
-        return self
+        return self.f
 
     def __init__(self, f):
         self.f = f
+
     def __call__(self, *args, **kwargs):
         return self.f(*args, **kwargs)
 
 class BaseDecoratorWithArguments(object):
 
     def __init__(self, *args, **kwargs):
-        # If there are decorator arguments, only the decorator arguments are passed to the constructor.
-        # Not the to-be-decorated function.
-        self.args = args
-        self.kwargs = kwargs
+        # because we are so fake we don't give a shit about the arguments
+        pass
 
-    def __call__(self, f, *args, **kwargs):
-        # If there are decorator arguments, __call__() is only called once, as part of the decoration process.
-        # You can only give it a single argument, which is the function object.
-        def wrapped_func(*args, **kwargs):
-            return f(*args, **kwargs)
-        return wrapped_func
+    def __call__(self, f):
+        # just pretend no decorator was there at all haha
+        return f
+
+
+class Spooler(BaseDecorator):
+    def __init__(self, f=None, pass_arguments=False):
+        # this is strange because spool can be used either with or without
+        # keyword arguments.
+        if f is not None and callable(f):
+            def wrapped_func(**kwargs):
+                return f(kwargs)
+            super(Spooler, self).__init__(wrapped_func)
+        else:
+            self.pass_arguments = pass_arguments
+
+    def __call__(self, f=None, **kwargs):
+        # spool is crap because it could be called with or without arguments.
+        if f is not None and callable(f):
+            if self.pass_arguments:  # with pass_arguments spool is just normal
+                return BaseDecorator(f)
+            else:  # keyword arguments are passed as a dict to spool
+                def wrapped_func(**kwargs):
+                    return f(kwargs)
+                return BaseDecorator(wrapped_func)
+        else:
+            super(Spooler, self).__call__(f=f, **kwargs)
+
 
 try:
     from uwsgidecorators import *
@@ -29,7 +50,7 @@ except ImportError:
     class lock(BaseDecorator):
         pass
 
-    class spool(BaseDecorator):
+    class spool(Spooler):
         pass
 
     class cron(BaseDecoratorWithArguments):


### PR DESCRIPTION
::

    @spool
    def henk(args):
        print args['haha']

    henk.spool(haha="dommekut")

but also like this::

    @spool(pass_arguments=True)
    def kees(henk, ieltje, klaas=None):
        print henk, ieltje, klaas

    kees.spool(1, 'bah', klaas='geheheh')

Now that is supported.