### PR TITLE
Resolve warning related to logging.warn

### DIFF
--- a/uwsgidecoratorsfallback.py
+++ b/uwsgidecoratorsfallback.py
@@ -56,7 +56,7 @@ class Spooler(BaseDecorator):
 try:
     from uwsgidecorators import *
 except ImportError:
-    logger.warn("No uwsgidecorators module available, using fallbacks")
+    logger.warning("No uwsgidecorators module available, using fallbacks")
 
     class lock(BaseDecorator):
         pass


### PR DESCRIPTION
# Description
logging.warn **[deprecated](https://docs.python.org/3/library/logging.html#logging.Logger.warning)**, should be logging.warning.